### PR TITLE
Set metapackage version to 1.0.0 i.e. the same as

### DIFF
--- a/rslidar/package.xml
+++ b/rslidar/package.xml
@@ -1,7 +1,7 @@
 <package>
 
   <name>rslidar</name>
-  <version>1.1.0</version>
+  <version>1.0.0</version>
   <description>
     Basic ROS support for the Robosense 3D LIDARs.
   </description>


### PR DESCRIPTION
This is to fix the following error when running `catkin_prepare_release`:
```
Prepare the source repository for a release.
Repository type: git
Found packages: rslidar, rslidar_pointcloud, rslidar_driver, rslidar_sync, rslidar_msgs
Two packages have different version numbers (1.0.0 != 1.1.0):
- ./rslidar_pointcloud/package.xml
- ./rslidar/package.xml
```

`1.0.0` was chosen because all sub-packages are at version `1.0.0`.