### PR TITLE
Remove roslib from the list of dependencies

### DIFF
--- a/rslidar_driver/CMakeLists.txt
+++ b/rslidar_driver/CMakeLists.txt
@@ -10,7 +10,6 @@ set(${PROJECT_NAME}_CATKIN_DEPS
     angles
     pcl_ros
     roscpp
-    roslib
     sensor_msgs
     tf
     dynamic_reconfigure

--- a/rslidar_driver/package.xml
+++ b/rslidar_driver/package.xml
@@ -16,7 +16,6 @@
   <build_depend>pcl_ros</build_depend>
   <build_depend>pluginlib</build_depend>
   <build_depend>roscpp</build_depend>
-  <build_depend>roslib</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>tf</build_depend>
   <build_depend>dynamic_reconfigure</build_depend>
@@ -40,7 +39,6 @@
   <run_depend>pluginlib</run_depend>
   <!-- <run_depend>python-yaml</run_depend> -->
   <run_depend>roscpp</run_depend>
-  <run_depend>roslib</run_depend>
   <run_depend>rospy</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>tf</run_depend>

--- a/rslidar_pointcloud/CMakeLists.txt
+++ b/rslidar_pointcloud/CMakeLists.txt
@@ -8,7 +8,6 @@ set(${PROJECT_NAME}_CATKIN_DEPS
     nodelet
     pcl_ros
     roscpp
-    roslib
     sensor_msgs
     tf
     rslidar_driver

--- a/rslidar_pointcloud/package.xml
+++ b/rslidar_pointcloud/package.xml
@@ -20,7 +20,6 @@
   <build_depend>pcl_ros</build_depend>
   <build_depend>pluginlib</build_depend>
   <build_depend>roscpp</build_depend>
-  <build_depend>roslib</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>tf</build_depend>
   <build_depend>rslidar_driver</build_depend>
@@ -38,7 +37,6 @@
   <run_depend>pluginlib</run_depend>
   <!-- <run_depend>python-yaml</run_depend> -->
   <run_depend>roscpp</run_depend>
-  <run_depend>roslib</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>tf</run_depend>
   <run_depend>rslidar_driver</run_depend>

--- a/rslidar_sync/CMakeLists.txt
+++ b/rslidar_sync/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(rslidar_sync)
-find_package(catkin REQUIRED roscpp roslib std_msgs sensor_msgs message_filters)
+find_package(catkin REQUIRED roscpp std_msgs sensor_msgs message_filters)
 catkin_package()
 
 include_directories(include


### PR DESCRIPTION
Looking at this line,  https://github.com/seqsense/ros_rslidar/blob/eb85c540a27327e0f58635dc68803451471d7c56/rslidar_sync/CMakeLists.txt#L3 I noticed `roslib` was not defined as a dependency in the corresponding `package.xml` file.
Even without `roslib`, it seems possible to compile the whole metapackage so I removed it completely.